### PR TITLE
Sec3 audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ version = "0.19.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-multi-test",
  "cw-ownable 0.6.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,74 +2,74 @@
 members = ["packages/*", "contracts/*"]
 
 [workspace.package]
-version       = "0.19.0"
-edition       = "2021"
-license       = "Apache-2.0"
-repository    = "https://github.com/CosmWasm/cw-nfts"
-homepage      = "https://cosmwasm.com"
+version = "0.19.0"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/CosmWasm/cw-nfts"
+homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
-rust-version  = "1.78"
+rust-version = "1.78"
 
 [workspace.dependencies]
 anyhow = "^1.0"
 bech32 = "^0.11"
 cosmwasm-schema = "^1.5"
-cosmwasm-std    = "^1.5"
-cw2             = "^1.1"
-cw20            = "^1.1"
-cw721           = { version = "*", path = "./packages/cw721" }
-cw721-016       = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721" } # needed for backwards compatibility and legacy migration
-cw721-base      = { version = "*", path = "./contracts/cw721-base" }
-cw721-base-015  = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.15.0", package = "cw721-base" } # needed for testing legacy migration
-cw721-base-016  = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721-base" } # needed for testing legacy migration
-cw721-metadata-onchain-016  = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721-metadata-onchain" } # needed for testing legacy migration
-cw721-base-017  = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.17.0", package = "cw721-base" } # needed for testing legacy migration
-cw721-base-018  = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.18.0", package = "cw721-base" } # needed for testing legacy migration
+cosmwasm-std = "^1.5"
+cw2 = "^1.1"
+cw20 = "^1.1"
+cw721 = { version = "*", path = "./packages/cw721" }
+cw721-016 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721" } # needed for backwards compatibility and legacy migration
+cw721-base = { version = "*", path = "./contracts/cw721-base" }
+cw721-base-015 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.15.0", package = "cw721-base" } # needed for testing legacy migration
+cw721-base-016 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721-base" } # needed for testing legacy migration
+cw721-metadata-onchain-016 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.16.0", package = "cw721-metadata-onchain" } # needed for testing legacy migration
+cw721-base-017 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.17.0", package = "cw721-base" } # needed for testing legacy migration
+cw721-base-018 = { git = "https://github.com/CosmWasm/cw-nfts", tag = "v0.18.0", package = "cw721-base" } # needed for testing legacy migration
 cw1155 = { path = "./packages/cw1155", version = "*" }
 cw1155-base = { path = "./contracts/cw1155-base", version = "*" }
-cw-multi-test   = { version = "^0.20", features = ["cosmwasm_1_2"] }
-cw-ownable      = { git = "https://github.com/public-awesome/cw-plus-plus.git", rev = "28c1a09bfc6b4f1942fefe3eb0b50faf9d3b1523"} # TODO: switch to official https://github.com/larry0x/cw-plus-plus once merged
+cw-multi-test = { version = "^0.20" }
+cw-ownable = { git = "https://github.com/public-awesome/cw-plus-plus.git", rev = "28c1a09bfc6b4f1942fefe3eb0b50faf9d3b1523" } # TODO: switch to official https://github.com/larry0x/cw-plus-plus once merged
 cw-paginate-storage = { version = "^2.4", git = "https://github.com/DA0-DA0/dao-contracts.git" }
 cw-storage-plus = "^1.1"
-cw-utils        = "^1.0"
-schemars        = "^0.8"
-serde           = { version = "^1.0", default-features = false, features = ["derive"] }
+cw-utils = "^1.0"
+schemars = "^0.8"
+serde = { version = "^1.0", default-features = false, features = ["derive"] }
 sha2 = "^0.10"
-thiserror       = "^1.0"
-url             = "^2.5"
+thiserror = "^1.0"
+url = "^2.5"
 
 [profile.release.package.cw721-base]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw721-expiration]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw721-metadata-onchain]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw721-fixed-price]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw721-non-transferable]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw721-receiver-tester]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release.package.cw2981-royalties]
 codegen-units = 1
-incremental   = false
+incremental = false
 
 [profile.release]
-rpath            = false
-lto              = true
-overflow-checks  = true
-opt-level        = 3
-debug            = false
+rpath = false
+lto = true
+overflow-checks = true
+opt-level = 3
+debug = false
 debug-assertions = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,7 @@ fi
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  ${image}:0.15.1
+  ${image}:0.16.0
 """
 
 [tasks.schema]

--- a/contracts/cw1155-base/Cargo.toml
+++ b/contracts/cw1155-base/Cargo.toml
@@ -2,16 +2,16 @@
 name = "cw1155-base"
 authors = ["shab <dirtyshab@protonmail.com>"]
 description = "Basic implementation cw1155"
-version       = { workspace = true }
-edition       = { workspace = true }
-license       = { workspace = true }
-repository    = { workspace = true }
-homepage      = { workspace = true }
+version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
 documentation = { workspace = true }
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "artifacts/*",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "artifacts/*",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -36,3 +36,6 @@ cosmwasm-std = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 cosmwasm-schema = { workspace = true }
+
+[dev-dependencies]
+cw-multi-test = { workspace = true }

--- a/contracts/cw1155-base/src/contract_tests.rs
+++ b/contracts/cw1155-base/src/contract_tests.rs
@@ -1,27 +1,511 @@
 #[cfg(test)]
 mod tests {
+    use crate::entry::{execute, instantiate, query};
     use crate::{Cw1155BaseContract, Cw1155BaseExecuteMsg, Cw1155BaseQueryMsg};
+    use cosmwasm_schema::cw_serde;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{
-        from_json, to_json_binary, Addr, Binary, Empty, OverflowError, Response, StdError, Uint128,
+        coin, from_json, to_json_binary, wasm_execute, Addr, Binary, Empty, OverflowError,
+        Response, StdError, Uint128,
     };
     use cw1155::error::Cw1155ContractError;
     use cw1155::execute::Cw1155Execute;
     use cw1155::msg::{
         ApprovedForAllResponse, Balance, BalanceResponse, BalancesResponse, Cw1155InstantiateMsg,
         Cw1155MintMsg, Cw1155QueryMsg, IsApprovedForAllResponse, NumTokensResponse, OwnerToken,
-        TokenAmount, TokenInfoResponse,
+        TokenAmount, TokenApproval, TokenApprovalResponse, TokenInfoResponse,
     };
     use cw1155::query::Cw1155Query;
     use cw1155::receiver::Cw1155BatchReceiveMsg;
     use cw721::msg::TokensResponse;
     use cw721::Approval;
+    use cw_multi_test::{App, AppBuilder, ContractWrapper, Executor};
     use cw_ownable::OwnershipError;
     use cw_utils::Expiration;
 
+    const USEI: &str = "usei";
+
+    struct TestSuite {
+        pub app: App,
+        pub address_book: AddressBook,
+    }
+
+    impl TestSuite {
+        pub fn mint(
+            &mut self,
+            minter: Option<&Addr>,
+            recipient: &Addr,
+            token_id: &str,
+            amount: u64,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                minter.unwrap_or(&self.address_book.creator).clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::Mint {
+                        recipient: recipient.to_string(),
+                        msg: Cw1155MintMsg {
+                            token_id: token_id.to_string(),
+                            amount: amount.into(),
+                            token_uri: None,
+                            extension: None,
+                        },
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "mint succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error minting tokens: {:?}", res);
+            }
+        }
+
+        pub fn send(
+            &mut self,
+            sender: &Addr,
+            from: Option<&Addr>,
+            to: &Addr,
+            token_id: &str,
+            amount: u64,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                sender.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::Send {
+                        from: from.map(|f| f.to_string()),
+                        to: to.to_string(),
+                        token_id: token_id.to_string(),
+                        amount: amount.into(),
+                        msg: None,
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "send succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error sending tokens: {:?}", res);
+            }
+        }
+
+        pub fn send_batch(
+            &mut self,
+            sender: &Addr,
+            from: Option<&Addr>,
+            to: &Addr,
+            batch: Vec<TokenAmount>,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                sender.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::SendBatch {
+                        from: from.map(|f| f.to_string()),
+                        to: to.to_string(),
+                        batch,
+                        msg: None,
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "send batch succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error sending token batch: {:?}", res);
+            }
+        }
+
+        pub fn approve_token_spend(
+            &mut self,
+            owner: &Addr,
+            spender: &Addr,
+            token_id: &str,
+            amount: u64,
+            expires: Option<Expiration>,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::Approve {
+                        spender: spender.to_string(),
+                        token_id: token_id.to_string(),
+                        amount: amount.into(),
+                        expires,
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "approve succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error approving token spend: {:?}", res);
+            }
+        }
+
+        pub fn revoke_token_spend(
+            &mut self,
+            owner: &Addr,
+            spender: &Addr,
+            token_id: &str,
+            amount: Option<u64>,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::Revoke {
+                        spender: spender.to_string(),
+                        token_id: token_id.to_string(),
+                        amount: amount.map(Into::into),
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "revoke succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error revoking token spend: {:?}", res);
+            }
+        }
+
+        pub fn approve_all(
+            &mut self,
+            owner: &Addr,
+            operator: &Addr,
+            expires: Option<Expiration>,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::ApproveAll {
+                        operator: operator.to_string(),
+                        expires,
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "approve all succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error approving all: {:?}", res);
+            }
+        }
+
+        pub fn revoke_all(
+            &mut self,
+            owner: &Addr,
+            operator: &Addr,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::RevokeAll {
+                        operator: operator.to_string(),
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "revoke all succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error revoking all: {:?}", res);
+            }
+        }
+
+        pub fn burn(
+            &mut self,
+            owner: &Addr,
+            token_id: &str,
+            amount: u64,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::Burn {
+                        from: None,
+                        token_id: token_id.to_string(),
+                        amount: amount.into(),
+                    },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "burn succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error burning tokens: {:?}", res);
+            }
+        }
+
+        pub fn burn_batch(
+            &mut self,
+            owner: &Addr,
+            batch: Vec<TokenAmount>,
+            expected_error: Option<Cw1155ContractError>,
+        ) {
+            let res = self.app.execute(
+                owner.clone(),
+                wasm_execute(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseExecuteMsg::BurnBatch { from: None, batch },
+                    vec![],
+                )
+                .unwrap()
+                .into(),
+            );
+
+            if let Some(expected_error) = expected_error {
+                assert!(
+                    res.is_err(),
+                    "burn batch succeeded but expected error: {}",
+                    expected_error.to_string()
+                );
+                res.expect_err(&expected_error.to_string());
+            } else {
+                assert!(res.is_ok(), "error burning token batch: {:?}", res);
+            }
+        }
+
+        pub fn query_balance_of(&self, owner: &Addr, token_id: &str) -> BalanceResponse {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::BalanceOf(OwnerToken {
+                        owner: owner.to_string(),
+                        token_id: token_id.to_string(),
+                    }),
+                )
+                .unwrap()
+        }
+
+        pub fn query_balance_of_batch(&self, batch: Vec<OwnerToken>) -> BalancesResponse {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::BalanceOfBatch(batch),
+                )
+                .unwrap()
+        }
+
+        pub fn query_token_approvals(
+            &self,
+            owner: &Addr,
+            token_id: &str,
+        ) -> Vec<TokenApprovalResponse> {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::TokenApprovals {
+                        owner: owner.to_string(),
+                        token_id: token_id.to_string(),
+                        include_expired: None,
+                    },
+                )
+                .unwrap()
+        }
+
+        pub fn query_num_tokens(&self, token_id: Option<&str>) -> NumTokensResponse {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::NumTokens {
+                        token_id: token_id.map(ToString::to_string),
+                    },
+                )
+                .unwrap()
+        }
+
+        pub fn query_is_approved_for_all(
+            &self,
+            owner: &Addr,
+            operator: &Addr,
+        ) -> IsApprovedForAllResponse {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::IsApprovedForAll {
+                        owner: owner.to_string(),
+                        operator: operator.to_string(),
+                    },
+                )
+                .unwrap()
+        }
+
+        pub fn query_approvals_for_all(
+            &self,
+            owner: &Addr,
+            include_expired: Option<bool>,
+            start_after: Option<String>,
+            limit: Option<u32>,
+        ) -> ApprovedForAllResponse {
+            self.app
+                .wrap()
+                .query_wasm_smart(
+                    &self.address_book.cw1155,
+                    &Cw1155BaseQueryMsg::ApprovalsForAll {
+                        owner: owner.to_string(),
+                        include_expired,
+                        start_after,
+                        limit,
+                    },
+                )
+                .unwrap()
+        }
+    }
+
+    #[cw_serde]
+    struct AddressBook {
+        pub cw1155: Addr,
+        pub creator: Addr,
+        pub user1: Addr,
+        pub user2: Addr,
+        pub user3: Addr,
+    }
+
+    impl AddressBook {
+        pub fn new(cw1155: &Addr, creator: &Addr) -> Self {
+            AddressBook {
+                cw1155: cw1155.clone(),
+                creator: creator.clone(),
+                user1: Addr::unchecked("user1"),
+                user2: Addr::unchecked("user2"),
+                user3: Addr::unchecked("user3"),
+            }
+        }
+    }
+
+    fn setup() -> TestSuite {
+        let mut app = AppBuilder::new().build(|router, _api, storage| {
+            // init test accounts with 1_000_000_000 usei (1_000 sei)
+            let funds = vec![coin(1_000_000_000, USEI)];
+            router
+                .bank
+                .init_balance(storage, &Addr::unchecked("user1"), funds.to_vec())
+                .unwrap();
+            router
+                .bank
+                .init_balance(storage, &Addr::unchecked("user2"), funds.to_vec())
+                .unwrap();
+            router
+                .bank
+                .init_balance(storage, &Addr::unchecked("user3"), funds.to_vec())
+                .unwrap();
+        });
+
+        // upload marketplace code
+        let cw1155_code_id = app.store_code(Box::new(ContractWrapper::new_with_empty(
+            execute,
+            instantiate,
+            query,
+        )));
+
+        let creator = Addr::unchecked("creator");
+
+        // init marketplace contract
+        let cw1155 = app
+            .instantiate_contract(
+                cw1155_code_id,
+                creator.clone(),
+                &Cw1155InstantiateMsg {
+                    name: "cw1155 base contract".to_string(),
+                    symbol: "CW1155".to_string(),
+                    minter: None,
+                },
+                &[],
+                "init cw1155",
+                None,
+            )
+            .unwrap();
+
+        let address_book = AddressBook::new(&cw1155, &creator);
+
+        TestSuite { app, address_book }
+    }
+
     #[test]
     fn check_transfers() {
-        let contract = Cw1155BaseContract::default();
         // A long test case that try to cover as many cases as possible.
         // Summary of what it does:
         // - try mint without permission, fail
@@ -39,99 +523,40 @@ mod tests {
         // - minter try to transfer, fail
         // - user1 burn token1
         // - user1 batch burn token2 and token3
-        let token1 = "token1".to_owned();
-        let token2 = "token2".to_owned();
-        let token3 = "token3".to_owned();
-        let minter = String::from("minter");
-        let user1 = String::from("user1");
-        let user2 = String::from("user2");
 
-        let mut deps = mock_dependencies();
-        let msg = Cw1155InstantiateMsg {
-            name: "name".to_string(),
-            symbol: "symbol".to_string(),
-            minter: Some(minter.to_string()),
-        };
-        let res = contract
-            .instantiate(
-                deps.as_mut(),
-                mock_env(),
-                mock_info("operator", &[]),
-                msg,
-                "contract_name",
-                "contract_version",
-            )
-            .unwrap();
-        assert_eq!(0, res.messages.len());
+        let mut suite = setup();
+        let AddressBook {
+            creator,
+            user1,
+            user2,
+            ..
+        } = suite.address_book.clone();
+        let token1 = "1";
+        let token2 = "2";
+        let token3 = "3";
 
         // invalid mint, user1 don't mint permission
-        let mint_msg = Cw1155BaseExecuteMsg::Mint {
-            recipient: user1.to_string(),
-            msg: Cw1155MintMsg {
-                token_id: token1.to_string(),
-                amount: 1u64.into(),
-                token_uri: None,
-                extension: None,
-            },
-        };
-        assert!(matches!(
-            contract.execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(user1.as_ref(), &[]),
-                mint_msg.clone(),
-            ),
-            Err(Cw1155ContractError::Ownership(OwnershipError::NotOwner))
-        ));
+        suite.mint(
+            Some(&user1),
+            &user1,
+            token1,
+            1,
+            Some(Cw1155ContractError::Ownership(OwnershipError::NotOwner)),
+        );
 
         // valid mint
-        assert_eq!(
-            contract
-                .execute(
-                    deps.as_mut(),
-                    mock_env(),
-                    mock_info(minter.as_ref(), &[]),
-                    mint_msg,
-                )
-                .unwrap(),
-            Response::new().add_attributes(vec![
-                ("action", "mint_single"),
-                ("sender", minter.as_str()),
-                ("recipient", user1.as_str()),
-                ("token_id", token1.as_str()),
-                ("amount", "1"),
-            ])
-        );
+        suite.mint(None, &user1, token1, 1, None);
 
         // verify supply
+
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token1.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token1)),
             NumTokensResponse {
                 count: Uint128::one()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens { token_id: None },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(None),
             NumTokensResponse {
                 count: Uint128::one()
             }
@@ -139,190 +564,72 @@ mod tests {
 
         // query balance
         assert_eq!(
-            to_json_binary(&BalanceResponse {
+            BalanceResponse {
                 balance: 1u64.into()
-            }),
-            contract.query(
-                deps.as_ref(),
-                mock_env(),
-                Cw1155BaseQueryMsg::BalanceOf(OwnerToken {
-                    owner: user1.clone(),
-                    token_id: token1.clone(),
-                })
-            ),
+            },
+            suite.query_balance_of(&user1, token1),
         );
-
-        let transfer_msg = Cw1155BaseExecuteMsg::Send {
-            from: Some(user1.to_string()),
-            to: user2.clone(),
-            token_id: token1.clone(),
-            amount: 1u64.into(),
-            msg: None,
-        };
 
         // not approved yet
-        assert!(matches!(
-            contract.execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(minter.as_ref(), &[]),
-                transfer_msg.clone(),
-            ),
-            Err(Cw1155ContractError::Unauthorized {})
-        ));
+        suite.send(
+            &creator,
+            Some(&user1),
+            &user2,
+            token1,
+            1,
+            Some(Cw1155ContractError::Std(StdError::not_found("approval"))),
+        );
 
         // approve
-        contract
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(user1.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::ApproveAll {
-                    operator: minter.clone(),
-                    expires: None,
-                },
-            )
-            .unwrap();
+        suite.approve_token_spend(&user1, &creator, token1, 1, None, None);
 
         // transfer
-        assert_eq!(
-            contract
-                .execute(
-                    deps.as_mut(),
-                    mock_env(),
-                    mock_info(minter.as_ref(), &[]),
-                    transfer_msg,
-                )
-                .unwrap(),
-            Response::new().add_attributes(vec![
-                ("action", "transfer_single"),
-                ("owner", user1.as_str()),
-                ("sender", minter.as_str()),
-                ("recipient", user2.as_str()),
-                ("token_id", token1.as_str()),
-                ("amount", "1"),
-            ])
-        );
+        suite.send(&creator, Some(&user1), &user2, token1, 1, None);
 
         // query balance
         assert_eq!(
-            contract.query(
-                deps.as_ref(),
-                mock_env(),
-                Cw1155BaseQueryMsg::BalanceOf(OwnerToken {
-                    owner: user2.clone(),
-                    token_id: token1.clone(),
-                })
-            ),
-            to_json_binary(&BalanceResponse {
+            BalanceResponse {
                 balance: 1u64.into()
-            }),
+            },
+            suite.query_balance_of(&user2, token1),
         );
         assert_eq!(
-            contract.query(
-                deps.as_ref(),
-                mock_env(),
-                Cw1155BaseQueryMsg::BalanceOf(OwnerToken {
-                    owner: user1.clone(),
-                    token_id: token1.clone(),
-                })
-            ),
-            to_json_binary(&BalanceResponse {
+            BalanceResponse {
                 balance: 0u64.into()
-            }),
+            },
+            suite.query_balance_of(&user1, token1),
         );
 
         // mint token2 and token3
-        contract
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(minter.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::Mint {
-                    recipient: user2.clone(),
-                    msg: Cw1155MintMsg {
-                        token_id: token2.clone(),
-                        amount: 1u64.into(),
-                        token_uri: None,
-                        extension: None,
-                    },
-                },
-            )
-            .unwrap();
-
-        contract
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(minter.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::Mint {
-                    recipient: user2.clone(),
-                    msg: Cw1155MintMsg {
-                        token_id: token3.clone(),
-                        amount: 1u64.into(),
-                        token_uri: None,
-                        extension: None,
-                    },
-                },
-            )
-            .unwrap();
+        suite.mint(None, &user2, token2, 1, None);
+        suite.mint(None, &user2, token3, 1, None);
 
         // verify supply
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token2.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token2)),
             NumTokensResponse {
                 count: Uint128::one()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token3.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token3)),
             NumTokensResponse {
                 count: Uint128::one()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens { token_id: None },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(None),
             NumTokensResponse {
                 count: Uint128::new(3)
             }
         );
 
         // invalid batch transfer, (user2 not approved yet)
-        let batch_transfer_msg = Cw1155BaseExecuteMsg::SendBatch {
-            from: Some(user2.clone()),
-            to: user1.clone(),
-            batch: vec![
+        suite.send_batch(
+            &creator,
+            Some(&user2),
+            &user1,
+            vec![
                 TokenAmount {
                     token_id: token1.to_string(),
                     amount: 1u64.into(),
@@ -336,89 +643,57 @@ mod tests {
                     amount: 1u64.into(),
                 },
             ],
-            msg: None,
-        };
-        assert!(matches!(
-            contract.execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(minter.as_ref(), &[]),
-                batch_transfer_msg.clone(),
-            ),
-            Err(Cw1155ContractError::Unauthorized {}),
-        ));
+            Some(Cw1155ContractError::Std(StdError::not_found("approval"))),
+        );
 
-        // user2 approve
-        contract
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(user2.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::ApproveAll {
-                    operator: minter.clone(),
-                    expires: None,
-                },
-            )
-            .unwrap();
+        // user2 approve all
+        suite.approve_all(&user2, &creator, None, None);
 
         // verify approval status
         assert_eq!(
-            contract.query(
-                deps.as_ref(),
-                mock_env(),
-                Cw1155QueryMsg::IsApprovedForAll {
-                    owner: user1.to_string(),
-                    operator: minter.to_string(),
-                },
-            ),
-            to_json_binary(&IsApprovedForAllResponse { approved: true })
+            suite.query_is_approved_for_all(&user2, &creator),
+            IsApprovedForAllResponse { approved: true }
         );
 
         // valid batch transfer
-        assert_eq!(
-            contract
-                .execute(
-                    deps.as_mut(),
-                    mock_env(),
-                    mock_info(minter.as_ref(), &[]),
-                    batch_transfer_msg,
-                )
-                .unwrap(),
-            Response::new().add_attributes(vec![
-                ("action", "transfer_batch"),
-                ("owner", user2.as_str()),
-                ("sender", minter.as_str()),
-                ("recipient", user1.as_str()),
-                ("token_ids", &format!("{},{},{}", token1, token2, token3)),
-                ("amounts", "1,1,1"),
-            ])
+        suite.send_batch(
+            &creator,
+            Some(&user2),
+            &user1,
+            vec![
+                TokenAmount {
+                    token_id: token1.to_string(),
+                    amount: 1u64.into(),
+                },
+                TokenAmount {
+                    token_id: token2.to_string(),
+                    amount: 1u64.into(),
+                },
+                TokenAmount {
+                    token_id: token3.to_string(),
+                    amount: 1u64.into(),
+                },
+            ],
+            None,
         );
 
         // batch query
         assert_eq!(
-            from_json(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::BalanceOfBatch(vec![
-                            OwnerToken {
-                                owner: user1.clone(),
-                                token_id: token1.clone(),
-                            },
-                            OwnerToken {
-                                owner: user1.clone(),
-                                token_id: token2.clone(),
-                            },
-                            OwnerToken {
-                                owner: user1.clone(),
-                                token_id: token3.clone(),
-                            }
-                        ]),
-                    )
-                    .unwrap()
-            ),
-            Ok(BalancesResponse {
+            suite.query_balance_of_batch(vec![
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token1.to_string(),
+                },
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token2.to_string(),
+                },
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token3.to_string(),
+                }
+            ]),
+            BalancesResponse {
                 balances: vec![
                     Balance {
                         token_id: token1.to_string(),
@@ -436,126 +711,45 @@ mod tests {
                         amount: Uint128::one(),
                     }
                 ]
-            }),
+            },
         );
 
         // user1 revoke approval
-        contract
-            .execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(user1.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::RevokeAll {
-                    operator: minter.clone(),
-                },
-            )
-            .unwrap();
+        suite.revoke_all(&user1, &creator, None);
 
         // query approval status
-        let approvals: ApprovedForAllResponse = from_json(
-            contract
-                .query(
-                    deps.as_ref(),
-                    mock_env(),
-                    Cw1155QueryMsg::ApprovalsForAll {
-                        owner: user1.clone(),
-                        include_expired: None,
-                        start_after: None,
-                        limit: None,
-                    },
-                )
-                .unwrap(),
-        )
-        .unwrap();
-        assert!(
-            approvals.operators.is_empty()
-                || !approvals
-                    .operators
-                    .iter()
-                    .all(|approval| approval.spender == minter)
+        assert_eq!(
+            suite.query_approvals_for_all(&user1, None, None, None),
+            ApprovedForAllResponse { operators: vec![] }
         );
 
         assert_eq!(
-            contract.query(
-                deps.as_ref(),
-                mock_env(),
-                Cw1155QueryMsg::IsApprovedForAll {
-                    owner: user1.to_string(),
-                    operator: minter.to_string(),
-                },
-            ),
-            to_json_binary(&IsApprovedForAllResponse { approved: false })
+            suite.query_is_approved_for_all(&user1, &creator),
+            IsApprovedForAllResponse { approved: false }
         );
 
         // transfer without approval
-        assert!(matches!(
-            contract.execute(
-                deps.as_mut(),
-                mock_env(),
-                mock_info(minter.as_ref(), &[]),
-                Cw1155BaseExecuteMsg::Send {
-                    from: Some(user1.clone()),
-                    to: user2,
-                    token_id: token1.clone(),
-                    amount: 1u64.into(),
-                    msg: None,
-                },
-            ),
-            Err(Cw1155ContractError::Unauthorized {})
-        ));
+        suite.send(
+            &creator,
+            Some(&user1),
+            &user2,
+            token1,
+            1,
+            Some(Cw1155ContractError::Std(StdError::not_found("approval"))),
+        );
 
         // burn token1
-        assert_eq!(
-            contract
-                .execute(
-                    deps.as_mut(),
-                    mock_env(),
-                    mock_info(user1.as_ref(), &[]),
-                    Cw1155BaseExecuteMsg::Burn {
-                        from: None,
-                        token_id: token1.clone(),
-                        amount: 1u64.into(),
-                    },
-                )
-                .unwrap(),
-            Response::new().add_attributes(vec![
-                ("action", "burn_single"),
-                ("owner", user1.as_str()),
-                ("sender", user1.as_str()),
-                ("token_id", &token1),
-                ("amount", "1"),
-            ])
-        );
+        suite.burn(&user1, token1, 1, None);
 
         // verify supply
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token1.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token1)),
             NumTokensResponse {
                 count: Uint128::zero()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens { token_id: None },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(None),
             NumTokensResponse {
                 count: Uint128::new(2)
             }
@@ -563,101 +757,43 @@ mod tests {
 
         // verify balance
         assert_eq!(
-            from_json::<BalanceResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::BalanceOf(OwnerToken {
-                            owner: user1.clone(),
-                            token_id: token1.clone(),
-                        }),
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_balance_of(&user1, token1),
             BalanceResponse {
                 balance: Uint128::zero()
             }
         );
 
         // burn them all
-        assert_eq!(
-            contract
-                .execute(
-                    deps.as_mut(),
-                    mock_env(),
-                    mock_info(user1.as_ref(), &[]),
-                    Cw1155BaseExecuteMsg::BurnBatch {
-                        from: None,
-                        batch: vec![
-                            TokenAmount {
-                                token_id: token2.to_string(),
-                                amount: 1u64.into(),
-                            },
-                            TokenAmount {
-                                token_id: token3.to_string(),
-                                amount: 1u64.into(),
-                            },
-                        ],
-                    },
-                )
-                .unwrap(),
-            Response::new().add_attributes(vec![
-                ("action", "burn_batch"),
-                ("owner", user1.as_str()),
-                ("sender", user1.as_str()),
-                ("token_ids", &format!("{},{}", token2, token3)),
-                ("amounts", "1,1"),
-            ])
+        suite.burn_batch(
+            &user1,
+            vec![
+                TokenAmount {
+                    token_id: token2.to_string(),
+                    amount: 1u64.into(),
+                },
+                TokenAmount {
+                    token_id: token3.to_string(),
+                    amount: 1u64.into(),
+                },
+            ],
+            None,
         );
 
         // verify supply
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token2.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token2)),
             NumTokensResponse {
                 count: Uint128::zero()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens {
-                            token_id: Some(token3.clone()),
-                        },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(Some(token3)),
             NumTokensResponse {
                 count: Uint128::zero()
             }
         );
         assert_eq!(
-            from_json::<NumTokensResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::NumTokens { token_id: None },
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_num_tokens(None),
             NumTokensResponse {
                 count: Uint128::zero()
             }
@@ -665,35 +801,26 @@ mod tests {
 
         // verify balances
         assert_eq!(
-            from_json::<BalancesResponse>(
-                contract
-                    .query(
-                        deps.as_ref(),
-                        mock_env(),
-                        Cw1155BaseQueryMsg::BalanceOfBatch(vec![
-                            OwnerToken {
-                                owner: user1.clone(),
-                                token_id: token2.clone(),
-                            },
-                            OwnerToken {
-                                owner: user1.clone(),
-                                token_id: token3.clone(),
-                            },
-                        ]),
-                    )
-                    .unwrap()
-            )
-            .unwrap(),
+            suite.query_balance_of_batch(vec![
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token2.to_string(),
+                },
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token3.to_string(),
+                }
+            ]),
             BalancesResponse {
                 balances: vec![
                     Balance {
                         token_id: token2.to_string(),
-                        owner: Addr::unchecked(&user1),
+                        owner: Addr::unchecked(user1.to_string()),
                         amount: Uint128::zero(),
                     },
                     Balance {
                         token_id: token3.to_string(),
-                        owner: Addr::unchecked(&user1),
+                        owner: Addr::unchecked(user1.to_string()),
                         amount: Uint128::zero(),
                     }
                 ]
@@ -1513,5 +1640,367 @@ mod tests {
                 extension: None,
             })
         );
+    }
+
+    #[test]
+    fn check_token_approvals() {
+        let mut suite = setup();
+        let AddressBook {
+            user1,
+            user2,
+            user3,
+            ..
+        } = suite.address_book.clone();
+
+        let token_id = "1";
+
+        // mint tokens to user 1
+        suite.mint(None, &user1, token_id, 10u64, None);
+
+        // verify balance of owner 1
+        assert_eq!(
+            suite.query_balance_of(&user1, token_id),
+            BalanceResponse {
+                balance: 10u64.into()
+            }
+        );
+
+        // user 2 tries to send tokens from user 1 to user 3 without approval, should fail
+        suite.send(
+            &user2,
+            Some(&user1),
+            &user3,
+            token_id,
+            1u64,
+            Some(Cw1155ContractError::Std(StdError::not_found("approval"))),
+        );
+
+        // user 1 approves themselves (should fail)
+        suite.approve_token_spend(
+            &user1,
+            &user1,
+            token_id,
+            1u64,
+            None,
+            Some(Cw1155ContractError::Unauthorized {
+                reason: "Operator cannot be the owner".to_string(),
+            }),
+        );
+
+        // user1 approves user2 with 0 amount (should fail)
+        suite.approve_token_spend(
+            &user1,
+            &user2,
+            token_id,
+            0u64,
+            None,
+            Some(Cw1155ContractError::InvalidZeroAmount {}),
+        );
+
+        // user 1 approves user 2 with valid amount
+        suite.approve_token_spend(&user1, &user2, token_id, 1u64, None, None);
+
+        // verify user 1 balance is still same
+        assert_eq!(
+            suite.query_balance_of(&user1, token_id),
+            BalanceResponse {
+                balance: 10u64.into()
+            }
+        );
+
+        // verify user 2 balance is 0
+        assert_eq!(
+            suite.query_balance_of(&user2, token_id),
+            BalanceResponse {
+                balance: 0u64.into()
+            }
+        );
+
+        // user 2 approves user 3 even though they have no tokens
+        suite.approve_token_spend(&user2, &user3, token_id, 1u64, None, None);
+
+        // user 3 sends tokens from user 2 to themselves (should fail, user 2 has no tokens)
+        suite.send(
+            &user3,
+            Some(&user2),
+            &user3,
+            token_id,
+            1u64,
+            Some(Cw1155ContractError::NotEnoughTokens {
+                available: Uint128::zero(),
+                requested: Uint128::one(),
+            }),
+        );
+
+        // user 2 sends more tokens than approved to user 3 (should fail)
+        suite.send(
+            &user2,
+            Some(&user1),
+            &user3,
+            token_id,
+            2u64,
+            Some(Cw1155ContractError::NotEnoughTokens {
+                available: Uint128::one(),
+                requested: Uint128::new(2),
+            }),
+        );
+
+        // user 2 sends tokens to user 3 with user 1's balance
+        suite.send(&user2, Some(&user1), &user3, token_id, 1u64, None);
+
+        // verify user 1 balance is now 9
+        assert_eq!(
+            suite.query_balance_of(&user1, token_id),
+            BalanceResponse {
+                balance: 9u64.into()
+            }
+        );
+
+        // verify user 2 balance is still 0
+        assert_eq!(
+            suite.query_balance_of(&user2, token_id),
+            BalanceResponse {
+                balance: 0u64.into()
+            }
+        );
+
+        // verify user 3 balance is now 1
+        assert_eq!(
+            suite.query_balance_of(&user3, token_id),
+            BalanceResponse {
+                balance: 1u64.into()
+            }
+        );
+
+        // user 2 sends tokens to user 3 with user 1's balance (should fail, user 2 used up their approval)
+        suite.send(
+            &user2,
+            Some(&user1),
+            &user3,
+            token_id,
+            1u64,
+            Some(Cw1155ContractError::Std(StdError::not_found("approval"))),
+        );
+
+        // user 3 sends tokens to themselves from user 2 balance (should fail, user 2 has no tokens)
+        suite.send(
+            &user3,
+            Some(&user2),
+            &user3,
+            token_id,
+            1u64,
+            Some(Cw1155ContractError::NotEnoughTokens {
+                available: Uint128::zero(),
+                requested: Uint128::one(),
+            }),
+        );
+
+        // user 1 sends tokens to user 2
+        suite.send(&user1, Some(&user1), &user2, token_id, 1u64, None);
+
+        // verify balances
+        assert_eq!(
+            suite.query_balance_of_batch(vec![
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user2.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user3.to_string(),
+                    token_id: token_id.to_string(),
+                }
+            ]),
+            BalancesResponse {
+                balances: vec![
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user1.clone(),
+                        amount: 8u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user2.clone(),
+                        amount: 1u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user3.clone(),
+                        amount: 1u64.into(),
+                    }
+                ]
+            }
+        );
+
+        // user 3 sends more tokens to themselves than approved from user 2 balance (should fail, not approved up to requested amount)
+        suite.send(
+            &user3,
+            Some(&user2),
+            &user3,
+            token_id,
+            2u64,
+            Some(Cw1155ContractError::NotEnoughTokens {
+                available: Uint128::one(),
+                requested: Uint128::new(2),
+            }),
+        );
+
+        // user 3 sends tokens to themselves from user 2 balance with valid amount (should succeed this time)
+        suite.send(&user3, Some(&user2), &user3, token_id, 1u64, None);
+
+        // verify balances
+        assert_eq!(
+            suite.query_balance_of_batch(vec![
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user2.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user3.to_string(),
+                    token_id: token_id.to_string(),
+                }
+            ]),
+            BalancesResponse {
+                balances: vec![
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user1.clone(),
+                        amount: 8u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user2.clone(),
+                        amount: 0u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user3.clone(),
+                        amount: 2u64.into(),
+                    }
+                ]
+            }
+        );
+
+        // verify approvals (should all be used up)
+        assert_eq!(suite.query_token_approvals(&user1, token_id), vec![]);
+        assert_eq!(suite.query_token_approvals(&user2, token_id), vec![]);
+        assert_eq!(suite.query_token_approvals(&user3, token_id), vec![]);
+
+        // user 1 approves user 2 with amount 2
+        suite.approve_token_spend(&user1, &user2, token_id, 2u64, None, None);
+
+        // verify approvals
+        assert_eq!(
+            suite.query_token_approvals(&user1, token_id),
+            vec![TokenApprovalResponse {
+                operator: user2.clone(),
+                approval: TokenApproval {
+                    amount: 2u64.into(),
+                    expiration: Expiration::Never {},
+                }
+            }]
+        );
+
+        // user 1 revokes 1 amount from user 2
+        suite.revoke_token_spend(&user1, &user2, token_id, Some(1u64), None);
+
+        // verify approvals (amount 1 should be revoked)
+        assert_eq!(
+            suite.query_token_approvals(&user1, token_id),
+            vec![TokenApprovalResponse {
+                operator: user2.clone(),
+                approval: TokenApproval {
+                    amount: 1u64.into(),
+                    expiration: Expiration::Never {},
+                }
+            }]
+        );
+
+        // user 2 sends amount 2 to themselves from user 1 balance (should fail, not enough tokens after revoke)
+        suite.send(
+            &user2,
+            Some(&user1),
+            &user2,
+            token_id,
+            2u64,
+            Some(Cw1155ContractError::NotEnoughTokens {
+                available: Uint128::one(),
+                requested: Uint128::new(2),
+            }),
+        );
+
+        // user 2 sends amount 1 to user 1 from user 1 balance (should fail, cant send to self)
+        suite.send(
+            &user2,
+            Some(&user1),
+            &user1,
+            token_id,
+            1u64,
+            Some(Cw1155ContractError::Unauthorized {
+                reason: "Cannot send to self".to_string(),
+            }),
+        );
+
+        // verify approvals
+        assert_eq!(
+            suite.query_token_approvals(&user1, token_id),
+            vec![TokenApprovalResponse {
+                operator: user2.clone(),
+                approval: TokenApproval {
+                    amount: 1u64.into(),
+                    expiration: Expiration::Never {},
+                }
+            }]
+        );
+
+        // user 2 sends amount 1 to themselves from user 1 balance (should succeed)
+        suite.send(&user2, Some(&user1), &user2, token_id, 1u64, None);
+
+        // verify balances
+        assert_eq!(
+            suite.query_balance_of_batch(vec![
+                OwnerToken {
+                    owner: user1.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user2.to_string(),
+                    token_id: token_id.to_string(),
+                },
+                OwnerToken {
+                    owner: user3.to_string(),
+                    token_id: token_id.to_string(),
+                }
+            ]),
+            BalancesResponse {
+                balances: vec![
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user1.clone(),
+                        amount: 7u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user2.clone(),
+                        amount: 1u64.into(),
+                    },
+                    Balance {
+                        token_id: token_id.to_string(),
+                        owner: user3.clone(),
+                        amount: 2u64.into(),
+                    }
+                ]
+            }
+        );
+
+        // verify approvals
+        assert_eq!(suite.query_token_approvals(&user1, token_id), vec![]);
     }
 }

--- a/contracts/cw1155-base/src/contract_tests.rs
+++ b/contracts/cw1155-base/src/contract_tests.rs
@@ -64,7 +64,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "mint succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -102,7 +102,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "send succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -138,7 +138,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "send batch succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -175,7 +175,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "approve succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -210,7 +210,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "revoke succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -243,7 +243,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "approve all succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -274,7 +274,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "revoke all succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -308,7 +308,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "burn succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -337,7 +337,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "burn batch succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -365,7 +365,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "update default uri succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -399,7 +399,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "update token metadata succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -427,7 +427,7 @@ mod tests {
                 assert!(
                     res.is_err(),
                     "update token metadata batch succeeded but expected error: {}",
-                    expected_error.to_string()
+                    expected_error
                 );
                 res.expect_err(&expected_error.to_string());
             } else {
@@ -577,7 +577,7 @@ mod tests {
     fn setup(default_uri: Option<String>) -> TestSuite {
         let mut app = AppBuilder::new().build(|router, _api, storage| {
             // init test accounts with 1_000_000_000 usei (1_000 sei)
-            let funds = vec![coin(1_000_000_000, USEI)];
+            let funds = [coin(1_000_000_000, USEI)];
             router
                 .bank
                 .init_balance(storage, &Addr::unchecked("user1"), funds.to_vec())

--- a/contracts/cw1155-base/src/lib.rs
+++ b/contracts/cw1155-base/src/lib.rs
@@ -6,18 +6,16 @@ pub mod state;
 pub use crate::state::Cw1155Contract;
 use cosmwasm_std::Empty;
 use cw1155::msg::{Cw1155ExecuteMsg, Cw1155QueryMsg};
-use cw1155::state::{Cw1155Config, DefaultOptionMetadataExtension};
+use cw1155::state::Cw1155Config;
 
 // Version info for migration
 pub const CONTRACT_NAME: &str = "crates.io:cw1155-base";
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub type Cw1155BaseContract<'a> =
-    Cw1155Contract<'a, DefaultOptionMetadataExtension, Empty, Empty, Empty>;
-pub type Cw1155BaseExecuteMsg = Cw1155ExecuteMsg<DefaultOptionMetadataExtension, Empty>;
-pub type Cw1155BaseQueryMsg = Cw1155QueryMsg<DefaultOptionMetadataExtension, Empty>;
-pub type Cw1155BaseConfig<'a> =
-    Cw1155Config<'a, DefaultOptionMetadataExtension, Empty, Empty, Empty>;
+pub type Cw1155BaseContract<'a> = Cw1155Contract<'a, String, Empty, Empty, Empty>;
+pub type Cw1155BaseExecuteMsg = Cw1155ExecuteMsg<String, Empty>;
+pub type Cw1155BaseQueryMsg = Cw1155QueryMsg<String, Empty>;
+pub type Cw1155BaseConfig<'a> = Cw1155Config<'a, String, Empty, Empty, Empty>;
 
 pub mod entry {
     use super::*;
@@ -29,7 +27,6 @@ pub mod entry {
     use cw1155::execute::Cw1155Execute;
     use cw1155::msg::{Cw1155ExecuteMsg, Cw1155InstantiateMsg, Cw1155QueryMsg};
     use cw1155::query::Cw1155Query;
-    use cw1155::state::DefaultOptionMetadataExtension;
 
     // This makes a conscious choice on the various generics used by the contract
     #[cfg_attr(not(feature = "library"), entry_point)]
@@ -48,18 +45,14 @@ pub mod entry {
         deps: DepsMut,
         env: Env,
         info: MessageInfo,
-        msg: Cw1155ExecuteMsg<DefaultOptionMetadataExtension, Empty>,
+        msg: Cw1155ExecuteMsg<String, Empty>,
     ) -> Result<Response, Cw1155ContractError> {
         let tract = Cw1155BaseContract::default();
         tract.execute(deps, env, info, msg)
     }
 
     #[cfg_attr(not(feature = "library"), entry_point)]
-    pub fn query(
-        deps: Deps,
-        env: Env,
-        msg: Cw1155QueryMsg<DefaultOptionMetadataExtension, Empty>,
-    ) -> StdResult<Binary> {
+    pub fn query(deps: Deps, env: Env, msg: Cw1155QueryMsg<String, Empty>) -> StdResult<Binary> {
         let tract = Cw1155BaseContract::default();
         tract.query(deps, env, msg)
     }

--- a/contracts/cw1155-royalties/src/lib.rs
+++ b/contracts/cw1155-royalties/src/lib.rs
@@ -3,7 +3,7 @@ use cw1155::msg::{Cw1155ExecuteMsg, Cw1155QueryMsg};
 use cw1155::state::Cw1155Config;
 use cw1155_base::Cw1155Contract;
 use cw2981_royalties::msg::QueryMsg as Cw2981QueryMsg;
-use cw2981_royalties::DefaultOptionMetadataExtensionWithRoyalty;
+use cw2981_royalties::MetadataWithRoyalty;
 
 mod query;
 pub use query::query_royalties_info;
@@ -16,13 +16,11 @@ const CONTRACT_NAME: &str = "crates.io:cw1155-royalties";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type Cw1155RoyaltiesContract<'a> =
-    Cw1155Contract<'a, DefaultOptionMetadataExtensionWithRoyalty, Empty, Empty, Cw2981QueryMsg>;
-pub type Cw1155RoyaltiesExecuteMsg =
-    Cw1155ExecuteMsg<DefaultOptionMetadataExtensionWithRoyalty, Empty>;
-pub type Cw1155RoyaltiesQueryMsg =
-    Cw1155QueryMsg<DefaultOptionMetadataExtensionWithRoyalty, Cw2981QueryMsg>;
+    Cw1155Contract<'a, MetadataWithRoyalty, Empty, Empty, Cw2981QueryMsg>;
+pub type Cw1155RoyaltiesExecuteMsg = Cw1155ExecuteMsg<MetadataWithRoyalty, Empty>;
+pub type Cw1155RoyaltiesQueryMsg = Cw1155QueryMsg<MetadataWithRoyalty, Cw2981QueryMsg>;
 pub type Cw1155RoyaltiesConfig<'a> =
-    Cw1155Config<'a, DefaultOptionMetadataExtensionWithRoyalty, Empty, Empty, Cw2981QueryMsg>;
+    Cw1155Config<'a, MetadataWithRoyalty, Empty, Empty, Cw2981QueryMsg>;
 
 #[cfg(not(feature = "library"))]
 pub mod entry {
@@ -131,6 +129,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: None,
+            default_uri: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -167,6 +166,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: None,
+            default_uri: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -200,6 +200,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: None,
+            default_uri: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -244,6 +245,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: None,
+            default_uri: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 

--- a/contracts/cw2981-royalties/src/lib.rs
+++ b/contracts/cw2981-royalties/src/lib.rs
@@ -57,8 +57,9 @@ pub mod entry {
 
     use super::*;
 
+    use crate::error::ContractError;
     use cosmwasm_std::entry_point;
-    use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
+    use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
     use cw721::msg::Cw721InstantiateMsg;
     use cw721::traits::{Cw721Execute, Cw721Query};
     use state::Cw2981Contract;

--- a/packages/cw1155/src/error.rs
+++ b/packages/cw1155/src/error.rs
@@ -17,8 +17,8 @@ pub enum Cw1155ContractError {
     #[error("OwnershipError: {0}")]
     Ownership(#[from] OwnershipError),
 
-    #[error("Unauthorized")]
-    Unauthorized {},
+    #[error("Unauthorized: {reason}")]
+    Unauthorized { reason: String },
 
     #[error("Expired")]
     Expired {},

--- a/packages/cw1155/src/error.rs
+++ b/packages/cw1155/src/error.rs
@@ -32,6 +32,9 @@ pub enum Cw1155ContractError {
         requested: Uint128,
     },
 
-    #[error("Must provide either 'token_uri' or 'extension' to update.")]
-    NoUpdatesRequested {},
+    #[error("Must provide tokens to update.")]
+    EmptyUpdateRequest {},
+
+    #[error("No updates requested for token {token_id}. Must provide either 'token_uri' or 'metadata' to update.")]
+    NoUpdatesRequested { token_id: String },
 }

--- a/packages/cw1155/src/execute.rs
+++ b/packages/cw1155/src/execute.rs
@@ -442,7 +442,7 @@ pub trait Cw1155Execute<
         env: ExecuteEnv,
         operator: String,
         token_id: String,
-        amount: Option<Uint128>,
+        approval_amount: Uint128,
         expiration: Option<Expiration>,
     ) -> Result<Response<TCustomResponseMessage>, Cw1155ContractError> {
         let ExecuteEnv { deps, info, env } = env;
@@ -459,19 +459,9 @@ pub trait Cw1155Execute<
             return Err(Cw1155ContractError::Expired {});
         }
 
-        // get sender's token balance to get valid approval amount
-        let balance = config
-            .balances
-            .load(deps.storage, (info.sender.clone(), token_id.to_string()))?;
-        let approval_amount = amount.unwrap_or(balance.amount);
+        // validate approval amount
         if approval_amount.is_zero() {
             return Err(Cw1155ContractError::InvalidZeroAmount {});
-        }
-        if approval_amount > balance.amount {
-            return Err(Cw1155ContractError::NotEnoughTokens {
-                available: balance.amount,
-                requested: approval_amount,
-            });
         }
 
         // store the approval

--- a/packages/cw1155/src/execute.rs
+++ b/packages/cw1155/src/execute.rs
@@ -73,6 +73,11 @@ pub trait Cw1155Execute<
         // store total supply
         config.supply.save(deps.storage, &Uint128::zero())?;
 
+        // store default base uri
+        config
+            .default_base_uri
+            .save(deps.storage, &msg.default_uri)?;
+
         Ok(Response::default().add_attribute("minter", minter))
     }
 
@@ -900,7 +905,7 @@ pub trait Cw1155Execute<
         cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
         if updates.is_empty() {
-            return Err(Cw1155ContractError::NoUpdatesRequested {});
+            return Err(Cw1155ContractError::EmptyUpdateRequest {});
         }
 
         let config = Cw1155Config::<
@@ -918,13 +923,11 @@ pub trait Cw1155Execute<
                      token_uri,
                      metadata,
                  }| {
+                    let token_info = config.tokens.load(deps.storage, &token_id)?;
                     let (token_id, token_info) = config.update_token_metadata(
                         deps.storage,
                         &token_id,
-                        TokenInfo {
-                            token_uri: token_uri.clone(),
-                            extension: metadata.clone(),
-                        },
+                        token_info,
                         token_uri,
                         metadata.clone(),
                     )?;

--- a/packages/cw1155/src/execute.rs
+++ b/packages/cw1155/src/execute.rs
@@ -682,7 +682,7 @@ pub trait Cw1155Execute<
                     return Err(Cw1155ContractError::InvalidZeroAmount {});
                 }
                 // decrement token approvals from operator if different from balance owner
-                if from != &info.sender {
+                if from != info.sender {
                     let mut approval = config
                         .token_approves
                         .load(deps.storage, (token_id, from, &info.sender))

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -88,8 +88,8 @@ pub enum Cw1155ExecuteMsg<TMetadataExtension, TMetadataExtensionMsg> {
     Approve {
         spender: String,
         token_id: String,
-        /// Optional amount to approve. If None, approve entire balance.
-        amount: Option<Uint128>,
+        /// Amount to approve
+        amount: Uint128,
         expires: Option<Expiration>,
     },
     /// Remove previously granted Approval

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -238,7 +238,7 @@ pub struct AllTokenInfoResponse<T> {
 #[cw_serde]
 pub struct TokenInfoResponse<T> {
     /// Should be a url point to a json file
-    pub token_uri: Option<String>,
+    pub token_uri: String,
     /// You can add any custom metadata here when you extend cw1155-base
     pub extension: Option<T>,
 }

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -18,6 +18,10 @@ pub struct Cw1155InstantiateMsg {
     /// contract.
     /// If None, sender is the minter.
     pub minter: Option<String>,
+
+    /// optional default base token uri to prepend to token id for off-chain metadata.
+    /// If Some, this will be used as the base for all tokens without a set uri
+    pub default_uri: Option<String>,
 }
 
 /// This is like Cw1155ExecuteMsg but we add a Mint command for a minter
@@ -98,6 +102,14 @@ pub enum Cw1155ExecuteMsg<TMetadataExtension, TMetadataExtensionMsg> {
         token_id: String,
         /// Optional amount to revoke. If None, revoke entire amount.
         amount: Option<Uint128>,
+    },
+    /// Admin function to update default base token uri
+    UpdateDefaultUri { uri: Option<String> },
+    /// Admin function to update token uri for a batch of tokens
+    UpdateMetadata(TokenUpdate<TMetadataExtension>),
+    /// Admin function to update token uri for a batch of tokens
+    UpdateMetadataBatch {
+        updates: Vec<TokenUpdate<TMetadataExtension>>,
     },
 
     /// Extension msg
@@ -180,6 +192,9 @@ pub enum Cw1155QueryMsg<TMetadataExtension, TQueryExtensionMsg> {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    /// Default base token uri used for tokens without a set uri
+    #[returns(DefaultBaseUriResponse)]
+    DefaultBaseUri {},
 
     /// Extension query
     #[returns(())]
@@ -225,7 +240,7 @@ pub struct TokenInfoResponse<T> {
     /// Should be a url point to a json file
     pub token_uri: Option<String>,
     /// You can add any custom metadata here when you extend cw1155-base
-    pub extension: T,
+    pub extension: Option<T>,
 }
 
 #[cw_serde]
@@ -238,7 +253,7 @@ pub struct Cw1155MintMsg<T> {
     /// Metadata JSON Schema
     pub token_uri: Option<String>,
     /// Any custom extension used by this contract
-    pub extension: T,
+    pub extension: Option<T>,
 }
 
 #[cw_serde]
@@ -303,4 +318,16 @@ pub struct OwnersOfResponse {
 pub struct CollectionInfo {
     pub name: String,
     pub symbol: String,
+}
+
+#[cw_serde]
+pub struct TokenUpdate<TMetadataExtension> {
+    pub token_id: String,
+    pub token_uri: Option<String>,
+    pub metadata: Option<TMetadataExtension>,
+}
+
+#[cw_serde]
+pub struct DefaultBaseUriResponse {
+    pub uri: String,
 }

--- a/packages/cw1155/src/msg.rs
+++ b/packages/cw1155/src/msg.rs
@@ -125,7 +125,7 @@ pub enum Cw1155QueryMsg<TMetadataExtension, TQueryExtensionMsg> {
     #[returns(IsApprovedForAllResponse)]
     IsApprovedForAll { owner: String, operator: String },
     /// Return approvals that a token owner has
-    #[returns(Vec<crate::msg::TokenApproval>)]
+    #[returns(Vec<crate::msg::TokenApprovalResponse>)]
     TokenApprovals {
         owner: String,
         token_id: String,
@@ -255,6 +255,7 @@ impl Display for TokenAmount {
 }
 
 #[cw_serde]
+#[derive(Default)]
 pub struct TokenApproval {
     pub amount: Uint128,
     pub expiration: Expiration,
@@ -264,6 +265,19 @@ impl TokenApproval {
     pub fn is_expired(&self, env: &Env) -> bool {
         self.expiration.is_expired(&env.block)
     }
+
+    pub fn to_response(&self, operator: &Addr) -> TokenApprovalResponse {
+        TokenApprovalResponse {
+            operator: operator.clone(),
+            approval: self.clone(),
+        }
+    }
+}
+
+#[cw_serde]
+pub struct TokenApprovalResponse {
+    pub operator: Addr,
+    pub approval: TokenApproval,
 }
 
 #[cw_serde]

--- a/packages/cw1155/src/query.rs
+++ b/packages/cw1155/src/query.rs
@@ -140,9 +140,9 @@ pub trait Cw1155Query<
                     .prefix((&token_id, &owner))
                     .range(deps.storage, None, None, Order::Ascending)
                     .filter_map(|approval| {
-                        let (_, approval) = approval.unwrap();
+                        let (operator, approval) = approval.unwrap();
                         if include_expired.unwrap_or(false) || !approval.is_expired(&env) {
-                            Some(approval)
+                            Some(approval.to_response(&operator))
                         } else {
                             None
                         }

--- a/packages/cw1155/src/query.rs
+++ b/packages/cw1155/src/query.rs
@@ -226,7 +226,7 @@ pub trait Cw1155Query<
                 to_json_binary(&NumTokensResponse { count })
             }
             Cw1155QueryMsg::AllTokens { start_after, limit } => {
-                to_json_binary(&self.query_all_tokens_cw1155(deps, start_after, limit)?)
+                to_json_binary(&self.query_all_tokens(deps, start_after, limit)?)
             }
             Cw1155QueryMsg::Ownership {} => {
                 to_json_binary(&cw_ownable::get_ownership(deps.storage)?)
@@ -294,7 +294,7 @@ pub trait Cw1155Query<
         Ok(TokensResponse { tokens })
     }
 
-    fn query_all_tokens_cw1155(
+    fn query_all_tokens(
         &self,
         deps: Deps,
         start_after: Option<String>,

--- a/packages/cw1155/src/query.rs
+++ b/packages/cw1155/src/query.rs
@@ -194,12 +194,18 @@ pub trait Cw1155Query<
                         config
                             .default_base_uri
                             .load(deps.storage)
-                            .map(|base_uri| format!("{}{}", base_uri.unwrap_or_default(), token_id))
+                            .map(|base_uri| {
+                                if let Some(base_uri) = base_uri {
+                                    format!("{}{}", base_uri, token_id)
+                                } else {
+                                    "".to_string()
+                                }
+                            })
                             .ok()
                     })
                     .unwrap_or_default();
                 to_json_binary(&TokenInfoResponse::<TMetadataExtension> {
-                    token_uri: Some(token_uri),
+                    token_uri,
                     extension: token_info.extension,
                 })
             }

--- a/packages/cw1155/src/state.rs
+++ b/packages/cw1155/src/state.rs
@@ -182,7 +182,9 @@ where
         if metadata.is_none()
             && token_uri.clone().unwrap_or_default() == token_info.token_uri.unwrap_or_default()
         {
-            return Err(Cw1155ContractError::NoUpdatesRequested {});
+            return Err(Cw1155ContractError::NoUpdatesRequested {
+                token_id: token_id.to_string(),
+            });
         }
 
         // update metadata


### PR DESCRIPTION
**[P2-M-01] The approval amount is incorrectly subtracted from all approvals**
- token approval amount is no longer subtracted from all operators, and only subtracted from signing operator

**[P2-I-01] The "cw721::msg::MinterResponse" is deprecated**
- will keep this in mind in future iterations but will continue to use this deprecated response for now

**[P2-Q-01] CW1155 is different from ERC1155 about token_uri parameter**
- the difference in design is intentional, but to make it closer to ERC standard ive added the ability to pass a default base uri to the contract init entrypoint, and also added admin contract functions to allow the creator to change the default base uri as well as token uris for specific tokens.
- if token uri is not set for a given token, we will get the base token uri from storage, and if set will append the token id to the token uri to generate the token id's full token uri in responses

**[P2-Q-02] Is limiting approval amount by current balance intentional?**
- it was intentional, but your suggestion makes sense to instead follow approval behavior in cw20, so ive removed the limitation


closes #2 